### PR TITLE
Adds java interface delivery pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Layer Logstash
 
 This is a charm layer for logstash.
+
+
+### This charm is not stand-alone
+
+This charm makes use of `interface:java` which means you will need to deploy
+a compatible JRE along with the logstash service. This allows the consumer to
+swap the version of java being used by configuring the system's java installation.
+
+     juju deploy logstash
+     juju deploy openjdk
+     juju add-relation logstash openjdk
+ 

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,9 @@
 options:
-  apt-url:
+  install_sources:
     type: string
-    default: http://packages.elastic.co/logstash/2.2/debian stable main
+    default: deb http://packages.elastic.co/logstash/2.2/debian stable main
     description: APT repository to fetch logstash from
-  apt-key:
+  install_keys:
     type: string
     default: D88E42B4
     description: repository key

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,2 +1,2 @@
-includes: ["layer:basic", "layer:tls"]
+includes: ["layer:basic", "interface:java"]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,12 +7,7 @@ summary: |
   analytics system.
 subordinate: false
 provides:
-  logs:
-    interface: elasticsearch
-  tcp-input:
-    interface: logstash-tcp
-  udp-input:
-    interface: logstash-udp
-requires:
-  elasticsearch:
-    interface: elasticsearch
+  java:
+    interface: java
+    scope: container
+

--- a/reactive/logstash.py
+++ b/reactive/logstash.py
@@ -15,7 +15,7 @@ def messaging():
 # this is declared in the JRE provider. 
 @when('java.ready')
 @when_not('logstash.installed')
-def fetch_and_install():
+def fetch_and_install(logstash):
     configure_sources(config('apt-url'), config('apt-key'))
     apt_update()
     apt_install('logstash', fatal=True)

--- a/reactive/logstash.py
+++ b/reactive/logstash.py
@@ -15,9 +15,10 @@ def messaging():
 # this is declared in the JRE provider. 
 @when('java.ready')
 @when_not('logstash.installed')
-def fetch_and_install(logstash):
-    configure_sources(config('apt-url'), config('apt-key'))
+def fetch_and_install(java):
+    configure_sources()
     apt_update()
     apt_install('logstash', fatal=True)
     set_state('logstash.installed')
     status_set('active', 'logstash installed')
+

--- a/reactive/logstash.py
+++ b/reactive/logstash.py
@@ -5,8 +5,15 @@ from charmhelpers.core.fetch import configure_sources
 from charmhelpers.core.fetch import apt_install
 from charmhelpers.core.fetch import apt_update
 from charmhelpers.core.hookenv import config
+from charmhelpers.core.hookenv import status_set 
 
 
+@when_not('java.ready')
+def messaging():
+    status_set('blocked', 'Missing JRE')
+
+# this is declared in the JRE provider. 
+@when('java.ready')
 @when_not('logstash.installed')
 def fetch_and_install():
     configure_sources(config('apt-url'), config('apt-key'))

--- a/reactive/logstash.py
+++ b/reactive/logstash.py
@@ -1,11 +1,11 @@
 from charms.reactive import set_state
 from charms.reactive import when
 from charms.reactive import when_not
-from charmhelpers.core.fetch import configure_sources
-from charmhelpers.core.fetch import apt_install
-from charmhelpers.core.fetch import apt_update
 from charmhelpers.core.hookenv import config
 from charmhelpers.core.hookenv import status_set 
+from charmhelpers.fetch import configure_sources
+from charmhelpers.fetch import apt_install
+from charmhelpers.fetch import apt_update
 
 
 @when_not('java.ready')
@@ -20,3 +20,4 @@ def fetch_and_install():
     apt_update()
     apt_install('logstash', fatal=True)
     set_state('logstash.installed')
+    status_set('active', 'logstash installed')


### PR DESCRIPTION
This allows the end user to swap out the java JRE which is empowering logstash
by using a different subordinate.

This works ootb with ~kwmonroe/trusty/openjdk