### PR TITLE
Adds the client relation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,11 @@ options:
     type: string
     default: D88E42B4
     description: repository key
+  udp_port:
+    type: int
+    default: 5000
+    description: The port used by logstash agents to emit logs over UDP.
+  tcp_port:
+    type: int
+    default: 6000
+    description: The port used by logstash agents to emit logs over TCP.

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,1 +1,1 @@
-includes: ["layer:basic", "interface:java", "interface:elasticsearch"]
+includes: ["layer:basic", "interface:java", "interface:elasticsearch", "interface:logstash-client"]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,8 +10,9 @@ provides:
   java:
     interface: java
     scope: container
+  logstash:
+    interface: logstash-client
 
 requires:
   elasticsearch:
     interface: elasticsearch
-  

--- a/reactive/logstash.py
+++ b/reactive/logstash.py
@@ -3,6 +3,7 @@ from charms.reactive import remove_state
 from charms.reactive import when
 from charms.reactive import when_not
 from charms.reactive import when_file_changed
+from charmhelpers.core.hookenv import config
 from charmhelpers.core.hookenv import status_set
 from charmhelpers.core import host
 from charmhelpers.core.templating import render
@@ -55,3 +56,13 @@ def configure_logstash(elasticsearch):
 @when_file_changed('/etc/logstash/conf.d/output-elasticsearch.conf')
 def recycle_logstash_service():
     host.service_restart('logstash')
+
+
+@when('client.connected')
+def configure_logstash_input(client):
+    '''Configure the logstash input parameters.'''
+    # Send the port data to the clients.
+    client.provide_data(config('tcp_port'), config('udp_port'))
+    source = 'input.conf'
+    target = '/etc/logstash/conf.d/input.conf'
+    render(source, target, config())

--- a/reactive/logstash.py
+++ b/reactive/logstash.py
@@ -37,8 +37,6 @@ def trigger_logstash_service_recycle(elasticsearch):
 @when_not('logstash.elasticsearch.configured')
 def configure_logstash(elasticsearch):
     '''Configure logstash to push data to other sources.'''
-
-    # Set up the configration file for logstash.
     # Get cluster-name, host, port from the relationship object.
     units = elasticsearch.list_unit_data()
     hosts = []
@@ -50,10 +48,11 @@ def configure_logstash(elasticsearch):
     target = '/etc/logstash/conf.d/output-elasticsearch.conf'
     # Render the template
     render(source, target, context)
+    # Set up the configration file for logstash
     set_state('logstash.elasticsearch.configured')
 
 
-@when_file_changed('/etc/logstash/conf.d/output-elasticsearch.conf')
+@when_file_changed('/etc/logstash/conf.d/output-elasticsearch.conf', '/etc/logstash/conf.d/input.conf')  # noqa
 def recycle_logstash_service():
     host.service_restart('logstash')
 

--- a/templates/input.conf
+++ b/templates/input.conf
@@ -1,0 +1,16 @@
+{% if udp_port or tcp_port %}
+input {
+{% if udp_port %}
+  udp {
+    port => {{udp_port}}
+    codec => json
+  }
+{% endif %}
+
+{% if tcp_port %}
+  tcp {
+    port => {{tcp_port}}
+  }
+{% endif %}
+}
+{% endif %}


### PR DESCRIPTION
- This commit works in tandem with the `logstash-client` interface layer.
- Includes config options for setting the tcp and udp listening ports.
- Templates the input as `/etc/logstash/conf.d/input.conf`
- Recycles the `logstash` service if files in `/etc/logstash/conf.d/*` have changed