### PR TITLE
Fix actions.yaml params. Use default Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-build:
-	charm build --force

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,8 +1,8 @@
 generate-noise:
   description: |
     simulates noise -  this is useful when testing logstash shipping with no relations
-  options:
+  params:
     noise:
-      type: int
+      type: integer
       description: Number of lines of noise to generate
       default: 2000


### PR DESCRIPTION
Not sure why the actions.yaml was considered valid but when you were triggering the generate-noise action the noise param was not retrieved.

For the Makefile using the basic layer Makefile that has optional hooks for style checks and tests seems cooler :)